### PR TITLE
Added landuse data and updated TimeSeriesTransform to CompositeTimeSeriesTransform

### DIFF
--- a/Run_Env/config/agri_config.json
+++ b/Run_Env/config/agri_config.json
@@ -68,6 +68,32 @@
       "harvested": 0
     },
     {
+      "soil_type": "HAC"
+    },
+    {
+      "landtype": [""]
+    },
+    {
+      "landuse": [""]
+    },
+    {
+      "management": [""]
+    },
+    {
+      "input": [""]
+    },
+    {
+      "change": {
+        "transform": {
+          "allow_nulls": true,
+          "library": "moja.flint.example.agri",
+          "type": "CompositeTimeSeriesTransform",
+          "data_property": "data_yearly",
+          "vars": [ "landtype", "landuse", "management", "input"]
+        }
+      }
+    },
+    {
       "spatialLocationInfo": {
         "flintdata": {
           "library": "internal.flint",
@@ -124,6 +150,15 @@
       }
     },
     {
+      "landuseevents": {
+        "transform": {
+          "library": "moja.flint.example.agri",
+          "type": "SpatialTransform",
+          "data_property": "landuse"
+        }
+      }
+    },
+    {
       "landuse": {
         "transform": {
             "data_id": "land_use",
@@ -152,6 +187,26 @@
           "queryFile": "config/sql/Wet_Dry_Zone.sql"
         }
       }
+    },
+    {
+      "Soil_Stock_Change": {
+        "transform": {
+          "library": "internal.flint",
+          "type": "SQLQueryTransform",
+          "provider": "SQLite",
+          "queryFile": "config/sql/Soil_Stock_Change.sql"
+        }
+      }
+    },
+    {
+      "SOC_REF": {
+        "transform": {
+          "library": "internal.flint",
+          "type": "SQLQueryTransform",
+          "provider": "SQLite",
+          "queryFile": "config/sql/SOC_REF.sql"
+        }
+      }
     }
   ],
   "Modules": {
@@ -167,15 +222,19 @@
       "library": "moja.flint.example.agri",
       "order": 3
     },
+    "LandUseModule": {
+      "library": "moja.flint.example.agri",
+      "order": 4
+    },
     "DisturbanceEventModule": {
       "enabled": true,
       "library": "moja.flint.example.agri",
-      "order": 4
+      "order": 5
     },
     "OutputerStream": {
       "enabled": true,
       "library": "internal.flint",
-      "order": 5,
+      "order": 6,
       "settings": {
         "output_filename": "Example_Agri_Spatial_Stock.csv",
         "output_to_screen": false,
@@ -186,7 +245,7 @@
     "OutputerStreamFlux": {
       "enabled": true,
       "library": "internal.flint",
-      "order": 6,
+      "order": 7,
       "settings": {
         "output_filename": "Example_Agri_Spatial_Flux.csv",
         "output_to_screen": false,
@@ -196,7 +255,7 @@
     "WriteVariableGeotiff": {
       "enabled": true,
       "library": "moja.modules.gdal",
-      "order": 7,
+      "order": 8,
       "settings": {
         "output_path": "data/output/results/spatial_outputs/grids",
         "use_indexes_for_folder_name": true,

--- a/Run_Env/config/agri_config.json
+++ b/Run_Env/config/agri_config.json
@@ -56,10 +56,24 @@
       }
     },
     {
+      "EF_3": {
+        "cattle_default": 0.004,
+        "cattle_wet": 0.006,
+        "cattle_dry": 0.002,
+        "other": 0.003
+      }
+    },
+    {
       "ipcc_climate_zone" : "Tropical Dry"
     },
     {
+      "region": "Latin America"
+    },
+    {
       "crop_type" : "default"
+    },
+    {
+      "animal_type" : "default"
     },
     {
       "yield" : 0
@@ -145,7 +159,7 @@
         "transform": {
           "library": "moja.flint.example.agri",
           "type": "SpatialTransform",
-          "data_property": "harvest"
+          "data_property": "prp"
         }
       }
     },
@@ -205,6 +219,36 @@
           "type": "SQLQueryTransform",
           "provider": "SQLite",
           "queryFile": "config/sql/SOC_REF.sql"
+        }
+      }
+    },
+    {
+      "Animal_weights": {
+        "transform": {
+          "library": "internal.flint",
+          "type": "SQLQueryTransform",
+          "provider": "SQLite",
+          "queryFile": "config/sql/Animal_weights.sql"
+        }
+      }
+    },
+    {
+      "N_Excretion_rate": {
+        "transform": {
+          "library": "internal.flint",
+          "type": "SQLQueryTransform",
+          "provider": "SQLite",
+          "queryFile": "config/sql/N_Excretion_rate.sql"
+        }
+      }
+    },
+    {
+      "AWMS": {
+        "transform": {
+          "library": "internal.flint",
+          "type": "SQLQueryTransform",
+          "provider": "SQLite",
+          "queryFile": "config/sql/AWMS.sql"
         }
       }
     }

--- a/Run_Env/config/agri_point.json
+++ b/Run_Env/config/agri_point.json
@@ -55,48 +55,27 @@
       "soil_type": "HAC"
     },
     {
-      "landtype": {
+      "landtype": [ "F", "C", "C", "G", "G", "G"]
+    },
+    {
+      "landuse": [ "", "Long term cultivated", "Perennial crop", "", "", ""]
+    },
+    {
+      "change": {
         "transform": {
           "allow_nulls": true,
           "library": "moja.flint.example.agri",
-          "type": "TimeSeriesTransform",
+          "type": "CompositeTimeSeriesTransform",
           "data_property": "data_yearly",
-          "data_yearly": [ "F", "C", "C", "G", "G", "G"]
+          "vars": [ "landtype", "landuse", "management", "input"]
         }
       }
     },
     {
-      "landuse": {
-        "transform": {
-          "allow_nulls": true,
-          "library": "moja.flint.example.agri",
-          "type": "TimeSeriesTransform",
-          "data_property": "data_yearly",
-          "data_yearly": [ "", "Long term cultivated", "Perennial crop", "", "", ""]
-        }
-      }
+      "management": [ "", "Reduced", "Full", "High intensity grazing", "High intensity grazing", "High intensity grazing"]
     },
     {
-      "management": {
-        "transform": {
-          "allow_nulls": true,
-          "library": "moja.flint.example.agri",
-          "type": "TimeSeriesTransform",
-          "data_property": "data_yearly",
-          "data_yearly": [ "", "Reduced", "Full", "High intensity grazing", "High intensity grazing", "High intensity grazing"]
-        }
-      }
-    },
-    {
-      "input": {
-        "transform": {
-          "allow_nulls": true,
-          "library": "moja.flint.example.agri",
-          "type": "TimeSeriesTransform",
-          "data_property": "data_yearly",
-          "data_yearly": [ "", "Medium", "Medium", "High", "High", "High"]
-        }
-      }
+      "input": [ "", "Medium", "Medium", "High", "High", "High"]
     },
     {
       "region": "Latin America"

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/buildlandunitmodule.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/buildlandunitmodule.h
@@ -29,12 +29,11 @@ class BuildLandUnitModule : public flint::ModuleBase {
       void onPreTimingSequence() override;
 
    private:
-      flint::IVariable* landuse_;
       flint::IVariable* climate_;
       const flint::IVariable* zones_;
 };
 
-}  // namespace chapman_richards
-}  // namespace modules
+}  // namespace agri
+}  // namespace example
+}  // namespace flint
 }  // namespace moja
-}

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/disturbanceeventmodule.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/disturbanceeventmodule.h
@@ -43,7 +43,7 @@ class AGRI_API DisturbanceEventModule : public flint::ModuleBase, DisturbanceEve
    std::string climate;
 };
 
-}  // namespace chapman_richards
-}  // namespace modules
 }  // namespace agri
-}
+}  // namespace example
+}  // namespace flint
+}  // namespace moja

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/disturbanceevents.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/disturbanceevents.h
@@ -105,7 +105,7 @@ void DisturbanceEventsList::emplace_back(Args&&... args) {
    _list.emplace_back(std::forward<Args>(args)...);
 }
 
-}  // namespace chapman_richards
-}  // namespace modules
+}  // namespace agri
+}  // namespace example
+}  // namespace flint
 }  // namespace moja
-}

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/fertevents.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/fertevents.h
@@ -80,7 +80,7 @@ class PlantEvent final : public DisturbanceEventBase {
    std::string crop_type;
 };
 
-}  // namespace chapman_richards
-}  // namespace modules
+}  // namespace agri
+}  // namespace example
+}  // namespace flint
 }  // namespace moja
-}

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/landusemodule.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/landusemodule.h
@@ -1,5 +1,5 @@
-#ifndef MOJA_FLINT_EXAMPLE_ROTHC_ROTHCMODULE_H_
-#define MOJA_FLINT_EXAMPLE_ROTHC_ROTHCMODULE_H_
+#ifndef MOJA_FLINT_EXAMPLE_AGRI_LANDUSEMODULE_H_
+#define MOJA_FLINT_EXAMPLE_AGRI_LANDUSEMODULE_H_
 
 #include "moja/_core_exports.h"
 #include "moja/flint/imodule.h"
@@ -45,9 +45,9 @@ private:
     const flint::IVariable* _changeFactor;
 };
 
-}
-}
-}
-} 
+}  // namespace agri
+}  // namespace example
+}  // namespace flint
+}  // namespace moja
 
 #endif // MOJA_FLINT_EXAMPLE_AGRI_LANDUSEMODULE_H_

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/landusemodule.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/landusemodule.h
@@ -38,10 +38,7 @@ private:
     const flint::IPool* _atmosphere;
     const flint::IPool* _initialValues;
 
-	const flint::IVariable* _landType;
-	const flint::IVariable* _landUse;
-	const flint::IVariable* _management;
-	const flint::IVariable* _input;
+    const flint::IVariable* _change;
     const flint::IVariable* _climateZone;
     const flint::IVariable* _soilType;
     const flint::IVariable* _stockRef;

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/spatialtransform.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/spatialtransform.h
@@ -31,8 +31,8 @@ class AGRI_API SpatialTransform : public ITransform {
    mutable std::string _dataPropertyName;
 };
 
+}  // namespace agri
+}  // namespace example
 }  // namespace flint
 }  // namespace moja
-}
-}
 #endif  // MOJA_FLINT_LOCATIONIDXFROMFLINTDATATRANSFORM_H_

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/timeseriestransform.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/timeseriestransform.h
@@ -1,5 +1,5 @@
-#ifndef MOJA_FLINT_EXAMPLE_BASE_COMPOSITETRANSFORM_H_
-#define MOJA_FLINT_EXAMPLE_BASE_COMPOSITETRANSFORM_H_
+#ifndef MOJA_FLINT_EXAMPLE_AGRI_COMPOSITETRANSFORM_H_
+#define MOJA_FLINT_EXAMPLE_AGRI_COMPOSITETRANSFORM_H_
 
 #include "moja/flint/example/agri/_modules.agri_exports.h"
 
@@ -37,9 +37,9 @@ class CompositeTimeSeriesTransform : public flint::ITransform {
    mutable std::string _dataPropertyName;
 };
 
-}  // namespace base
+}  // namespace agri
 }  // namespace example
 }  // namespace flint
 }  // namespace moja
 
-#endif // MOJA_FLINT_EXAMPLE_BASE_COMPOSITETRANSFORM_H_
+#endif // MOJA_FLINT_EXAMPLE_AGRI_COMPOSITETRANSFORM_H_

--- a/Source/moja.flint.example.agri/include/moja/flint/example/agri/timeseriestransform.h
+++ b/Source/moja.flint.example.agri/include/moja/flint/example/agri/timeseriestransform.h
@@ -17,7 +17,7 @@ namespace flint {
 namespace example {
 namespace agri {
 
-class TimeSeriesTransform : public flint::ITransform {
+class CompositeTimeSeriesTransform : public flint::ITransform {
   public:
    enum Format { Wide, Long };
 
@@ -31,7 +31,8 @@ class TimeSeriesTransform : public flint::ITransform {
    const flint::ILandUnitController* _landUnitController;
    datarepository::DataRepository* _dataRepository;
 
-   std::vector<std::string> _values;
+   mutable std::vector<const IVariable*> _variables;
+   std::vector<std::string> _varNames;
    mutable DynamicVar _currentValue;
    mutable std::string _dataPropertyName;
 };

--- a/Source/moja.flint.example.agri/src/buildlandunitmodule.cpp
+++ b/Source/moja.flint.example.agri/src/buildlandunitmodule.cpp
@@ -72,6 +72,15 @@ void BuildLandUnitModule::onPreTimingSequence() {
          org_ev->quantity = temp["quantity"];
          org_ev->runtime = temp["runtime"];
          event_queue->emplace_back(date, org_ev);
+      
+      } else if (temp["type"] == "agri.PRPEvent") {
+         auto prp = std::make_shared<PRPEvent>(eventId++, "PRP Event");
+         auto date = temp["date"].extract<const DateTime>();
+         prp->animal_type = temp["animal"].extract<std::string>();
+         prp->no_livestock = temp["number"];
+         prp->productivity_class = temp["productivity_class"].extract<std::string>();
+         prp->use = temp["use"].extract<std::string>();
+         event_queue->emplace_back(date, prp);
       }
    }
 

--- a/Source/moja.flint.example.agri/src/fertevents.cpp
+++ b/Source/moja.flint.example.agri/src/fertevents.cpp
@@ -104,7 +104,7 @@ DynamicObject PlantEvent::exportObject() const {
 }
 
 void PlantEvent::simulate(DisturbanceEventHandler& event_handler) const { event_handler.simulate(*this); }
-}  // namespace chapman_richards
-}  // namespace modules
+}  // namespace agri
+}  // namespace example
+}  // namespace flint
 }  // namespace moja
-}

--- a/Source/moja.flint.example.agri/src/landusemodule.cpp
+++ b/Source/moja.flint.example.agri/src/landusemodule.cpp
@@ -50,11 +50,14 @@ void LandUseModule::InitializeForASimulation() {
 }
 
 void LandUseModule::SubmitMoves() {
+
     const auto changeFactor = _changeFactor->value().extract<const std::vector<DynamicObject>>();
-    const auto landType = _landType->value().extract<std::string>();
-    const auto landUse = _landUse->value().extract<std::string>();
-    const auto management = _management->value().extract<std::string>();
-    const auto input = _input->value().extract<std::string>();
+    const auto change = _change->value().extract<DynamicObject>();
+    
+    const auto landType = change["landtype"].extract<std::string>();
+    const auto landUse = change["landuse"].extract<std::string>();
+    const auto management = change["management"].extract<std::string>();
+    const auto input = change["input"].extract<std::string>();
 
     std::string str;
     auto EF_1 = _landUnitData->getVariable("EF_1")->value().extract<DynamicObject>();
@@ -130,10 +133,7 @@ void LandUseModule::onLocalDomainInit() {
 	_initialValues = _landUnitData->getPool("initial_values");
 
 	// Variables
-	_landType = _landUnitData->getVariable("landtype");
-	_landUse = _landUnitData->getVariable("landuse");
-	_management = _landUnitData->getVariable("management");
-	_input = _landUnitData->getVariable("input");
+    _change = _landUnitData->getVariable("change");
     _soilType = _landUnitData->getVariable("soil_type");
     _climateZone = _landUnitData->getVariable("ipcc_climate_zone");
     _stockRef = _landUnitData->getVariable("SOC_REF");

--- a/Source/moja.flint.example.agri/src/libraryfactory.cpp
+++ b/Source/moja.flint.example.agri/src/libraryfactory.cpp
@@ -41,7 +41,7 @@ extern "C" {
 
 	MOJA_LIB_API int getTransformRegistrations(TransformRegistration* outTransformRegistrations) {
 		int index = 0;
-		outTransformRegistrations[index++] = TransformRegistration{ "TimeSeriesTransform",	[]() -> flint::ITransform* { return new TimeSeriesTransform(); } };
+		outTransformRegistrations[index++] = TransformRegistration{ "CompositeTimeSeriesTransform",	[]() -> flint::ITransform* { return new CompositeTimeSeriesTransform(); } };
 		outTransformRegistrations[index++] = TransformRegistration{ "SpatialTransform",	[]() -> flint::ITransform* { return new SpatialTransform(); } };
 		return index;
 	}

--- a/Source/moja.flint.example.agri/src/spatialtransform.cpp
+++ b/Source/moja.flint.example.agri/src/spatialtransform.cpp
@@ -91,6 +91,17 @@ const DynamicVar& SpatialTransform::value() const {
       change.insert<std::vector<DynamicVar>>("input", input);
 
       _cachedValue = change;
+   } else if (_dataPropertyName == "prp") {
+      DynamicObject animals;
+      animals.insert<DateTime>("date", DateTime(2003, 8, 1));
+      animals.insert<std::string>("type", "agri.PRPEvent");
+      animals.insert<std::string>("animal", "Buffalo");
+      animals.insert<int>("number", 3);
+      animals.insert<std::string>("productivity_class", "High");
+      animals.insert<std::string>("use", "Other");
+      
+      events.emplace_back(animals);
+      _cachedValue = events;
    }
 
    return _cachedValue;

--- a/Source/moja.flint.example.agri/src/spatialtransform.cpp
+++ b/Source/moja.flint.example.agri/src/spatialtransform.cpp
@@ -7,6 +7,7 @@
 
 #include <moja/datarepository/datarepository.h>
 #include <moja/datarepository/iproviderspatialrasterinterface.h>
+#include <moja/logging.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -56,6 +57,7 @@ const DynamicVar& SpatialTransform::value() const {
       events.emplace_back(event1);
       events.emplace_back(event2);
       _cachedValue = events;
+
    } else if (_dataPropertyName == "fertilizer") {
       DynamicObject event1;
       event1.insert<std::string>("type", "agri.NFertEvent");
@@ -75,25 +77,22 @@ const DynamicVar& SpatialTransform::value() const {
       events.emplace_back(event2);
       _cachedValue = events;
    } else if (_dataPropertyName == "landuse") {
-      DynamicObject change1;
-      change1.insert<std::string>("type", "landuse");
-      change1.insert<DateTime>("date", DateTime(2001, 1, 1));
-      change1.insert<std::string>("landuse", "F");
-      change1.insert<std::string>("management", "");
-      change1.insert<std::string>("input", "");
+      DynamicObject change;
+      change.insert<std::string>("type", "landuse");
+      change.insert<std::string>("data_property", "data_yearly");
+      std::vector<DynamicVar> landtype{"F", "C", "C", "G", "G", "G"};
+      change.insert<std::vector<DynamicVar>>("landtype", landtype);
+      std::vector<DynamicVar> landuse{"", "Long term cultivated", "Perennial crop", "", "", ""};
+      change.insert<std::vector<DynamicVar>>("landuse", landuse);
+      std::vector<DynamicVar> management{
+          "", "Reduced", "Full", "High intensity grazing", "High intensity grazing", "High intensity grazing"};
+      change.insert<std::vector<DynamicVar>>("management", management);
+      std::vector<DynamicVar> input{"", "Medium", "Medium", "High", "High", "High"};
+      change.insert<std::vector<DynamicVar>>("input", input);
 
-      DynamicObject change2;
-      change2.insert<std::string>("type", "landuse");
-      change2.insert<DateTime>("date", DateTime(2003, 1, 1));
-      change2.insert<std::string>("landuse", "C");
-      change2.insert<std::string>("management", "Perennial crop");
-      change2.insert<std::string>("input", "Full");
-
-      events.emplace_back(change1);
-      events.emplace_back(change2);
-      _cachedValue = events;
+      _cachedValue = change;
    }
-   
+
    return _cachedValue;
 }
 


### PR DESCRIPTION
- Changed `TimeSeriesTransform` to `CompositeTimeSeriesTransform` as the config file included too many variables. 
`"change": {
        "transform": {
          "allow_nulls": true,
          "library": "moja.flint.example.agri",
          "type": "CompositeTimeSeriesTransform",
          "data_property": "data_yearly",
          "vars": [ "landtype", "landuse", "management", "input"]
        }
      }` This will written a `DynamicObject` variable with the vars as the keys.
- Added spatial land-use data in the `SpatialTransform`. `SpatialTransform` will return a `DynamicObject` which the `BuildLandUnitModule` uses to add data in the variables needed for `LandUseModule`.